### PR TITLE
Add non-succuss info from HTTP::Tiny

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,20 +26,22 @@ my %wm = (
     AUTHOR       => "H.Merijn Brand <hmbrand\@cpan.org>",
     VERSION_FROM => "lib/Net/CVE.pm",
     LICENSE      => "perl",
-    EXE_FILES    => [ @exe ],
+    EXE_FILES    => [@exe],
     PREREQ_FATAL => 0,
     PREREQ_PM    => {
 	# Core modules
-	"Carp"				=> 0,
-	"HTTP::Tiny"			=> 0.009,
-	"JSON::MaybeXS"			=> 1.004005,
-	"List::Util"			=> 0,
+	"Carp"          => 0,
+	"HTTP::Tiny"    => 0.009,
+	"JSON::MaybeXS" => 1.004005,
+	"List::Util"    => 0,
 
 	# For testing
-	"Test::More"			=> 0.90,
-	"Test::Warnings"		=> 0,
+	"Test::More"       => 0.90,
+	"Test::Warnings"   => 0,
+	"Test::MockObject" => 0,
+	"URI"              => 0,
 	},
-    macro        => { TARFLAGS   => "--format=ustar -c -v -f", },
+    macro => {TARFLAGS => "--format=ustar -c -v -f",},
     );
 
 if ($ENV{EXTENDED_TESTING}) { # for CpanCover and masochists

--- a/cpanfile
+++ b/cpanfile
@@ -17,6 +17,8 @@ on "configure" => sub {
 on "test" => sub {
     requires   "Test::More"               => "0.90";
     requires   "Test::Warnings";
+    requires   "Test::MockObject";
+    requires   "URI";
 
     recommends "Test::More"               => "1.302195";
     };

--- a/lib/Net/CVE.pm
+++ b/lib/Net/CVE.pm
@@ -66,6 +66,8 @@ sub get {
 	my $r = $self->{ua}->get ($url);
 	unless ($r->{success}) {
 	    #warn "$cve: $r->{status} $r->{reason}\n";
+	    my $error = "$r->{status} $r->{reason}";
+	    $r->{content} and $error .= ": $r->{content}";
 	    $self->{diag} = {
 		status => $r->{status},
 		reason => $r->{reason},
@@ -73,6 +75,19 @@ sub get {
 		url    => $url,
 		usage  => undef,
 		};
+	    $self->{data} = {
+	     containers => {
+	      cna => {
+	       descriptions => [{
+		value => $error,
+		}],
+	       problemTypes => [{
+	        descriptions => [{
+	         description => "Fetch URL",
+	         url         => $url,
+	         type        => "Error",
+	         }],
+	       }] }}};
 	    return $self;
 	    }
 	$self->{data} = decode_json ($r->{content});

--- a/t/30-get.t
+++ b/t/30-get.t
@@ -5,6 +5,8 @@ use warnings;
 
 use Test::More;
 use Test::Warnings;
+use Test::MockObject;
+use URI;
 
 use Net::CVE;
 
@@ -28,5 +30,69 @@ is_deeply (Net::CVE->new->data ("CVE-2022-26928"), $d1, "Data direct");
 is_deeply (Net::CVE->new->summary  ("2022-26928"), $s1, "Summary direct");
 
 is_deeply (Net::CVE->new->get ("")->data, {},		"Empty fetch");
+
+{
+    my $url = "http://392.168.42.42/cve";
+    my $ua  = HTTP::Tiny->new (agent => 'Net::CVE/1.00', SSL_verify => 1);
+    my $nc  = Net::CVE->new (
+	{   ua  => $ua,
+	    url => $url,
+	    });
+    isa_ok ($nc, 'Net::CVE');
+    is ($nc->{ua},  $ua,  "Custom user agent");
+    is ($nc->{url}, $url, "Custom url");
+    my $cve = $nc->get ("CVE-2022-26928");
+    is_deeply (
+	$cve->data ()->{containers}{cna}{descriptions}, [
+	    {   value =>
+		    "599 Internal Exception: Could not connect to \'392.168.42.42:80\': nodename nor servname provided, or not known\n"
+		    }
+	    ],
+	"Internal error"
+	)
+	or diag (explain ($cve->data ()));
+    }
+
+{
+    my $ua = Test::MockObject->new ();
+    $ua->mock (
+	get => sub {
+	    my $self = shift;
+	    my ($url) = URI->new (shift);
+	    (my $cve = $url->path) =~ s{^ .+/ (?=CVE.+) }{}x;
+	    open my $fh, "<:encoding(utf-8)",
+		"Files/${cve}.json"
+		or return {
+		success => 0,
+		status  => 404,
+		reason  => 'NOT FOUND',
+		content => undef,
+		};
+	    my $content = do { local $/; <$fh> };
+	    close $fh;
+	    return {
+		success => 1,
+		status  => 200,
+		reason  => 'OK',
+		content => $content,
+		};
+		});
+    $ua->set_isa ("HTTP::Tiny");
+    my $nc = Net::CVE->new ({ua => $ua});
+    isa_ok ($nc, 'Net::CVE');
+    is     ($nc->{ua}, $ua, "Custom user agent");
+    my $cve = $nc->get ("CVE-2022-26928");
+    is ($cve->data ()->{cveMetadata}{cveId},
+	"CVE-2022-26928", "Found correct CVE")
+	or diag (explain ($cve->data ()));
+
+    $cve = $nc->get ("CVE-2038-26928");
+    is_deeply (
+	$cve->data ()->{containers}{cna}{descriptions},
+	[{value => "404 NOT FOUND"}],
+	"Not found ok"
+	)
+	or diag (explain ($cve->data ()));
+    }
 
 done_testing;


### PR DESCRIPTION
If a request with HTTP::Tiny was not successful, there is often extra information in the 'content' field of the response. This change adds that to the error message. Also adds some tests for this.