### PR TITLE
Promote Data::Peek to requirement, since it's used in cve.pl, ++

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ MYMETA.json
 pm_to_blib
 *.tar.gz
 *.tgz
+*.bak
 *.old
 *.o
 *.c

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -30,3 +30,5 @@ pod2htmd\.tmp
 \.perlcriticrc
 ^CVE\.pm
 ^cve\.pl
+.*~$
+.*\.bak$

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -19,6 +19,7 @@ unless (exists $ENV{AUTOMATED_TESTING} and $ENV{AUTOMATED_TESTING} == 1) {
 	    push @exe => "scripts/$_->[0]";
 	}
     }
+
 my %wm = (
     NAME         => "Net::CVE",
     DISTNAME     => "Net-CVE",
@@ -34,6 +35,9 @@ my %wm = (
 	"HTTP::Tiny"		=> 0.009,
 	"JSON::MaybeXS"		=> 1.004005,
 	"List::Util"		=> 0,
+
+	# cve.pl uses Data::Peek
+	"Data::Peek"        => 0.52,
 
 	# For https
 	"IO::Socket::SSL"	=> 1.42,

--- a/cpanfile
+++ b/cpanfile
@@ -4,9 +4,9 @@ requires   "HTTP::Tiny"               => "0.009";
 requires   "IO::Socket::SSL"          => "1.42";
 requires   "JSON::MaybeXS"            => "1.004005";
 requires   "List::Util";
+requires   "Data::Peek"               => "0.52";
 
 recommends "Data::Dumper"             => "2.188";
-recommends "Data::Peek"               => "0.52";
 recommends "HTTP::Tiny"               => "0.088";
 recommends "IO::Socket::SSL"          => "2.085";
 

--- a/xt/10_perm.t
+++ b/xt/10_perm.t
@@ -2,9 +2,14 @@
 
 use 5.014002;
 use warnings;
+use Test::More;
 
-eval "use Test::PAUSE::Permissions";
- 
 BEGIN { $ENV{RELEASE_TESTING} = 1; }
 
+eval "use Test::PAUSE::Permissions" if $ENV{RELEASE_TESTING};
+
+plan skip_all => "Test::PAUSE::Permissions required for this test" if $@;
+
 all_permissions_ok ("HMBRAND");
+
+done_testing;


### PR DESCRIPTION
- Minor fixes in metadata
- Don't run xt/10_perm.t if required module isn't available